### PR TITLE
podspec fixed: ** to reference subfolders, non existent 'AnotherFramewor...

### DIFF
--- a/MBCalendarKit.podspec
+++ b/MBCalendarKit.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license 	 = 'MIT'
   s.platform     = :ios, '5.0'
   s.source       = { :git => "https://github.com/MosheBerman/MBCalendarKit.git", :tag => "1.0.1"} 
-  s.source_files  = 'Classes', 'MBCalendarKit/CalendarKit/*.{h,m}'
-  s.frameworks = 'QuartzCore', 'AnotherFramework'
+  s.source_files  = 'Classes', 'MBCalendarKit/CalendarKit/**/*.{h,m}'
+  s.frameworks = 'QuartzCore'
   s.requires_arc = true
 end


### PR DESCRIPTION
I was not able to used MBCalendarkit, due to some bugs in podspec file:
- it references only the files at folder MBCalendarKit/CalendarKit, and not the files inside subfolders
- it also lists 'AnotherFramework' in podspec, and that framework doesn't exist.

I fixed these bugs and could use CalendarKit in my project. Thanks!
