### PR TITLE
Fix to delegate declaration.

### DIFF
--- a/MBCalendarKit/CalendarKit/Core/CKCalendarView.h
+++ b/MBCalendarKit/CalendarKit/Core/CKCalendarView.h
@@ -28,8 +28,8 @@
 @property (nonatomic, strong) NSDate *maximumDate;
 
 
-@property (nonatomic, assign) id<CKCalendarViewDataSource> dataSource;
-@property (nonatomic, assign) id<CKCalendarViewDelegate> delegate;
+@property (nonatomic, weak) id<CKCalendarViewDataSource> dataSource;
+@property (nonatomic, weak) id<CKCalendarViewDelegate> delegate;
 
 /* Initializer */
 


### PR DESCRIPTION
...this fix uses the weak feature to nil out the reference during the dealloc process.
