### PR TITLE
Update Podspec to refer to 3.0.3 release and tag

### DIFF
--- a/MBCalendarKit.podspec
+++ b/MBCalendarKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "MBCalendarKit"
-  s.version      = "3.0.2"
+  s.version      = "3.0.3"
   s.summary      = "An open source calendar view for iOS."
   s.description  = <<-DESC
 	MBCalendarKit is a calendar control written in UIKit. I've found existing implementations to be inadequate and difficult to work with, so I rolled my own.
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { "Moshe Berman" => "moshberm@gmail.com" }
   s.license 	 = 'MIT'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/MosheBerman/MBCalendarKit.git", :tag => "2.2.7"} 
+  s.source       = { :git => "https://github.com/MosheBerman/MBCalendarKit.git", :tag => "3.0.3"} 
   s.source_files  = 'Classes', 'MBCalendarKit/CalendarKit/**/*.{h,m}'
   s.frameworks = 'QuartzCore'
   s.requires_arc = true


### PR DESCRIPTION
Updates current podspec to point for 3.0.3 release as a partial solution for #67.

If merged the following steps would also be needed to address #67: 
 1.  3.0.3 tag would also need to be updated to include to this commit
 2. Push updated spec to cocoapods trunk (see http://guides.cocoapods.org/making/specs-and-specs-repo.html) 

