### PR TITLE
Update Podspec to take version from podspec version to simplify releasin...

### DIFF
--- a/MBCalendarKit.podspec
+++ b/MBCalendarKit.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { "Moshe Berman" => "moshberm@gmail.com" }
   s.license 	 = 'MIT'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/MosheBerman/MBCalendarKit.git", :tag => "3.0.3"} 
+  s.source       = { :git => "https://github.com/MosheBerman/MBCalendarKit.git", :tag => s.version.to_s} 
   s.source_files  = 'Classes', 'MBCalendarKit/CalendarKit/**/*.{h,m}'
   s.frameworks = 'QuartzCore'
   s.requires_arc = true


### PR DESCRIPTION
The current podspec was still referring to the 3.0.3 tag. This change will mean you won't need to change this in future instead it will take the version frmo the podspec version (i.e. in this case "3.0.4").